### PR TITLE
fix typo in variable names starting with account_

### DIFF
--- a/R/posts.R
+++ b/R/posts.R
@@ -170,7 +170,7 @@ ct_parse_posts <- function(x, recursive = FALSE) {
     pb$tick()
     account <- tibble::as_tibble(
       p$account,
-      .name_repair = function(x) paste0("accout_", x)
+      .name_repair = function(x) paste0("account_", x)
     )
     statistics <- tibble::as_tibble(
       t(p$statistics),


### PR DESCRIPTION
There was a typo in the posts.R script which led to variable names starting with "accout_" instead of "account_". This should be fixed by this pull request.